### PR TITLE
chore(backstage): Add catalog-info.yaml config file

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: InstagramGallery
+  annotations:
+    github.com/project-slug: danielBroadhurst/InstagramGallery
+spec:
+  type: other
+  lifecycle: unknown
+  owner: dan


### PR DESCRIPTION

This pull request adds a **Backstage entity metadata file** to this repository so that the component can be added to the [ATG Digital Backstage software catalog](http://localhost:3000).

After this pull request is merged, the component will become available.

We would recommend that you add the following annotations to the file:

- `github.com/project-slug`: `atg-digital/<repo-slug>`
- `github.com/team-slug`: `dir:.` (if you are adding TechDocs to the repository)

Useful spec values are:

- `spec.type`: `service`
- `spec.lifecycle`: `production` (or `experimental` if you are not sure)
- `spec.owner`: `team-services`
- `spec.system`: `catalogue`

For more information, read an [overview of the Backstage software catalog](https://backstage.io/docs/features/software-catalog/).